### PR TITLE
Support propagating events as other events 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ You can unpropagate by ending the propagation like this:
   var p = propagate(['event1', 'event2'], ee1, ee2);
 ```
 
+## Propagate certain events as other events:
+
+```javascript
+  var ee1 = new EventEmitter();
+  var ee2 = new EventEmitter();
+  var p = propagate({
+    'event1': 'other-event1',
+    'event2': 'other-event2'
+  }, ee1, ee2);
+```
+
 # License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ function propagate(events, source, dest) {
     events = undefined;
   }
 
-  // events should be an array
-  if (events && ! Array.isArray(events)) events = [events];
+  // events should be an array or object
+  var eventsIsObject = typeof events === 'object'
+  if (events && !eventsIsObject) events = [events];
 
-  if (Array.isArray(events)) {
+  if (eventsIsObject) {
     return explicitPropagate(events, source, dest);
   }
 
@@ -33,8 +34,19 @@ function propagate(events, source, dest) {
 module.exports = propagate;
 
 function explicitPropagate(events, source, dest) {
+  var eventsIn;
+  var eventsOut;
+  if (Array.isArray(events)) {
+    eventsIn = events;
+    eventsOut = events;
+  } else {
+    eventsIn = Object.keys(events);
+    eventsOut = eventsIn.map(function (key) {
+      return events[key]
+    })
+  }
 
-  var listeners = events.map(function(event) {
+  var listeners = eventsOut.map(function(event) {
     return function() {
       var args = Array.prototype.slice(arguments);
       args.unshift(event);
@@ -49,11 +61,11 @@ function explicitPropagate(events, source, dest) {
   };
 
   function register(listener, i) {
-    source.on(events[i], listener);
+    source.on(eventsIn[i], listener);
   }
 
   function unregister(listener, i) {
-    source.removeListener(events[i], listener);
+    source.removeListener(eventsIn[i], listener);
   }
 
   function end() {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function explicitPropagate(events, source, dest) {
 
   var listeners = eventsOut.map(function(event) {
     return function() {
-      var args = Array.prototype.slice(arguments);
+      var args = Array.prototype.slice.call(arguments);
       args.unshift(event);
       dest.emit.apply(dest, args);
     }

--- a/tests/index.js
+++ b/tests/index.js
@@ -86,3 +86,34 @@ test('is able to propagate only certain events', function(t) {
 
   ee1.emit('event-1');
 });
+
+test('is able to propagate and map certain events', function(t) {
+  t.plan(2);
+  var ee1 = new EventEmitter();
+  var ee2 = new EventEmitter();
+  // propagate only event-1 and event-2, leaving out
+  var p = propagate({
+    'event-1': 'other-event-1',
+    'event-2': 'other-event-2'
+  }, ee1, ee2);
+
+  ee2.on('other-event-1', function() {
+    t.ok(true, 'event 1 received');
+  });
+
+  ee2.on('other-event-2', function(a, b, c) {
+    t.ok(true, 'event 2 received');
+  });
+
+  ee2.on('event-3', function(a, b, c) {
+    t.ok(false, 'event 3 should not have been received');
+  });
+
+  ee1.emit('event-1');
+  ee1.emit('event-2');
+  ee1.emit('event-3');
+
+  p.end();
+
+  ee1.emit('event-1');
+});


### PR DESCRIPTION
Added support for propagate event mapping with tests and docs.

Example:
```js
  var ee1 = new EventEmitter();
  var ee2 = new EventEmitter();
  var p = propagate({
    'event1': 'other-event1',
    'event2': 'other-event2'
  }, ee1, eel);
```